### PR TITLE
Fix SAMD toolsDependencies to match platform.txt

### DIFF
--- a/bpt.ini
+++ b/bpt.ini
@@ -166,12 +166,12 @@ index_template =
        {{
          "packager": "arduino",
          "name": "arm-none-eabi-gcc",
-         "version": "4.8.3-2014q1"
+         "version": "7-2017q4"
        }},
        {{
          "packager": "arduino",
          "name": "bossac",
-         "version": "1.7.0"
+         "version": "1.7.0-arduino3"
        }},
        {{
          "packager": "arduino",
@@ -181,7 +181,7 @@ index_template =
        {{
          "packager": "arduino",
          "name": "openocd",
-         "version": "0.9.0-arduino"
+         "version": "0.10.0-arduino7"
        }},
        {{
          "packager": "arduino",
@@ -192,6 +192,11 @@ index_template =
          "packager": "arduino",
          "name": "CMSIS-Atmel",
          "version": "1.2.0"
+       }},
+       {{
+         "packager": "arduino",
+         "name": "arduinoOTA",
+         "version": "1.2.1"
        }}
      ]
   }}


### PR DESCRIPTION
changes: bpt.ini

Fix: toolsDependencies (tools to download) must match tools and versions required by associated platform.txt

This pr only addresses future version builds of **package_adafruit_index.json** for SAMD toolsDependencies... as long as platform.txt versions do not change (please keep in sync).
Current and several past versions are still incorrect because their toolsDependencies are out of sync with their respective platform.txt.